### PR TITLE
docs: fix a typo in chart view

### DIFF
--- a/docs/chart-view.md
+++ b/docs/chart-view.md
@@ -1,7 +1,7 @@
 # Chart View (Beta)
 - The feature is useful for Response Data Visualisation
 - Create charts or tables from response using `tc.chartHTML()` from the Tests tab scripting
-- When you pass data to function `tc.chartHTML(templace, data)`, the data is available in `chart_data` global variable
+- When you pass data to function `tc.chartHTML(template, data)`, the data is available in `chart_data` global variable
 - The feature is in Beta, please test and let us know feedback
 
 ```js


### PR DESCRIPTION
There is what looks like a typo in Chart View documentation.

Is `templace` but looks like it should be `template`.